### PR TITLE
feat: limit transaction invocation to one per init steps

### DIFF
--- a/tests/restaking/1_initialize.ts
+++ b/tests/restaking/1_initialize.ts
@@ -50,7 +50,7 @@ describe("initialize", async () => {
         const {
             fragSOLMint,
             fragSOLExtraAccountMetasAccount,
-        } = await restaking.runAdminInitializeMint();
+        } = await restaking.runAdminTransferMintAuthority();
 
         expect(fragSOLMint.mintAuthority.toString()).eq(restaking.knownAddress.fragSOLTokenMintAuthority.toString());
         expect(fragSOLExtraAccountMetasAccount.length).eq(6);

--- a/tools/restaking/playground.ts
+++ b/tools/restaking/playground.ts
@@ -44,6 +44,27 @@ export class RestakingPlayground extends AnchorPlayground<Restaking, KEYCHAIN_KE
         });
     }
 
+    public get initializeSteps() {
+        if (this._initializeSteps) return this._initializeSteps;
+        return this._initializeSteps = this._getInitializeSteps();
+    }
+    private _initializeSteps: ReturnType<typeof this._getInitializeSteps>;
+    private _getInitializeSteps() {
+        return [
+            () => this.runAdminInitializeTokenMint(),
+            () => this.runAdminInitializeFundAccounts,
+            () => this.runAdminUpdateRewardAccounts,
+            () => this.runAdminTransferMintAuthority,
+            () => this.runFundManagerInitializeFundConfigurations,
+            () => this.runFundManagerInitializeRewardPools,
+            () => this.runFundManagerSettleReward({
+                poolName: 'bonus',
+                rewardName: 'fPoint',
+                amount: new BN(0),
+            }),
+        ]
+    }
+
     public get knownAddress() {
         if (this._knownAddress) return this._knownAddress;
         return this._knownAddress = this._getKnownAddress();
@@ -434,7 +455,7 @@ export class RestakingPlayground extends AnchorPlayground<Restaking, KEYCHAIN_KE
         return { fragSOLFundAccount };
     }
 
-    public async runAdminInitializeMint() {
+    public async runAdminTransferMintAuthority() {
         await this.run({
             instructions: [
                 this.program.methods


### PR DESCRIPTION
## Title
<!-- Title : feat/(issue num) -->
- feat: limit transaction invocation to one per init steps

## **🔘 Part**
- [x] LRT - LRT Program

## **🔎 What have been done**
<!-- _feat_: A new feature - minor -->
<!-- _fix_: A bug fix - patch -->
<!-- _perf_: A code change that improves performance -->
<!-- _chore_: A task that is not a code change -->
<!-- _refactor_: A code change that neither fixes a bug nor adds a feature -->
<!-- _build_: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm) -->
<!-- _ci_: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs) -->
<!-- _style_: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) -->
<!-- _test_: Adding missing tests or correcting existing tests -->
- feat: limit transaction invocation to one per init steps
- feat: add `initializeSteps` property to facilitate admin/fund manager operations

## **Issue or Ticket Tag**
<!-- Link related issue for project for this feature -->
- #
