### PR TITLE
fix(restaking/fund): remove sol reserved migration logic, and prefund…

### DIFF
--- a/programs/restaking/src/lib.rs
+++ b/programs/restaking/src/lib.rs
@@ -47,7 +47,6 @@ pub mod restaking {
         .process_initialize_fund_account(
             &ctx.accounts.receipt_token_program,
             &ctx.accounts.admin,
-            &ctx.accounts.fund_reserve_account,
             ctx.bumps.fund_account,
         )
     }
@@ -67,7 +66,6 @@ pub mod restaking {
         .process_update_fund_account_if_needed(
             &ctx.accounts.payer,
             &ctx.accounts.system_program,
-            &ctx.accounts.fund_reserve_account,
             desired_account_size,
         )
     }

--- a/programs/restaking/src/modules/fund/fund_account.rs
+++ b/programs/restaking/src/modules/fund/fund_account.rs
@@ -122,14 +122,13 @@ impl FundAccount {
         receipt_token_mint: Pubkey,
         receipt_token_decimals: u8,
         receipt_token_supply: u64,
-        sol_operation_reserved_amount: u64,
     ) -> Result<()> {
         if self.data_version == 0 {
             self.receipt_token_mint = receipt_token_mint;
             self.receipt_token_program = token_2022::ID;
             self.receipt_token_decimals = receipt_token_decimals;
             self.receipt_token_supply_amount = receipt_token_supply;
-            self.sol.initialize(None, sol_operation_reserved_amount);
+            self.sol.initialize(None, 0);
 
             // Must calculate addresses at last
             self.bump = bump;
@@ -164,14 +163,12 @@ impl FundAccount {
         &mut self,
         bump: u8,
         receipt_token_mint: &InterfaceAccount<Mint>,
-        sol_operation_reserved_amount: u64,
     ) -> Result<()> {
         self.migrate(
             bump,
             receipt_token_mint.key(),
             receipt_token_mint.decimals,
             receipt_token_mint.supply,
-            sol_operation_reserved_amount,
         )
     }
 
@@ -179,9 +176,8 @@ impl FundAccount {
     pub(super) fn update_if_needed(
         &mut self,
         receipt_token_mint: &InterfaceAccount<Mint>,
-        sol_operation_reserved_amount: u64,
     ) -> Result<()> {
-        self.initialize(self.bump, receipt_token_mint, sol_operation_reserved_amount)
+        self.initialize(self.bump, receipt_token_mint)
     }
 
     #[inline(always)]
@@ -1050,7 +1046,7 @@ mod tests {
     fn create_initialized_fund_account() -> FundAccount {
         let buffer = [0u8; 8 + std::mem::size_of::<FundAccount>()];
         let mut fund = FundAccount::try_deserialize_unchecked(&mut &buffer[..]).unwrap();
-        fund.migrate(0, Pubkey::new_unique(), 9, 0, 0).unwrap();
+        fund.migrate(0, Pubkey::new_unique(), 9, 0).unwrap();
         fund
     }
 

--- a/programs/restaking/src/modules/fund/fund_configuration_service.rs
+++ b/programs/restaking/src/modules/fund/fund_configuration_service.rs
@@ -41,18 +41,15 @@ impl<'a, 'info> FundConfigurationService<'a, 'info> {
         &mut self,
         receipt_token_program: &Program<'info, Token2022>,
         receipt_token_mint_current_authority: &Signer<'info>,
-        fund_reserve_account: &SystemAccount,
         fund_account_bump: u8,
     ) -> Result<()> {
         if self.fund_account.as_ref().data_len() < 8 + std::mem::size_of::<FundAccount>() {
             self.fund_account
                 .initialize_zero_copy_header(fund_account_bump)?;
         } else {
-            self.fund_account.load_init()?.initialize(
-                fund_account_bump,
-                self.receipt_token_mint,
-                fund_reserve_account.lamports(),
-            )?;
+            self.fund_account
+                .load_init()?
+                .initialize(fund_account_bump, self.receipt_token_mint)?;
         }
 
         // set token mint authority
@@ -77,7 +74,6 @@ impl<'a, 'info> FundConfigurationService<'a, 'info> {
         &self,
         payer: &Signer<'info>,
         system_program: &Program<'info, System>,
-        fund_reserve_account: &SystemAccount,
         desired_account_size: Option<u32>,
     ) -> Result<()> {
         let min_account_size = 8 + std::mem::size_of::<FundAccount>();
@@ -96,7 +92,7 @@ impl<'a, 'info> FundConfigurationService<'a, 'info> {
         if new_account_size >= min_account_size {
             self.fund_account
                 .load_mut()?
-                .update_if_needed(self.receipt_token_mint, fund_reserve_account.lamports())?;
+                .update_if_needed(self.receipt_token_mint)?;
         }
 
         Ok(())

--- a/programs/restaking/src/modules/fund/fund_service.rs
+++ b/programs/restaking/src/modules/fund/fund_service.rs
@@ -1199,7 +1199,7 @@ impl<'info: 'a, 'a> FundService<'info, 'a> {
                         CpiContext::new_with_signer(
                             system_program.to_account_info(),
                             anchor_lang::system_program::Transfer {
-                                from: fund_treasury_account.clone(),
+                                from: fund_treasury_account.to_account_info(),
                                 to: program_revenue_account.to_account_info(),
                             },
                             &[&fund_account.get_treasury_account_seeds()],

--- a/programs/restaking/tests/__snapshots__/fragbtc.test.ts.snap
+++ b/programs/restaking/tests/__snapshots__/fragbtc.test.ts.snap
@@ -33,6 +33,10 @@ exports[`restaking.fragBTC test > restaking.fragBTC initializationTasks snapshot
   [
     "Program ComputeBudget111111111111111111111111111111 invoke [1]",
     "Program ComputeBudget111111111111111111111111111111 success",
+    "Program 11111111111111111111111111111111 invoke [1]",
+    "Program 11111111111111111111111111111111 success",
+    "Program 11111111111111111111111111111111 invoke [1]",
+    "Program 11111111111111111111111111111111 success",
     "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
     "Program log: CreateIdempotent",
     "Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb invoke [2]",

--- a/programs/restaking/tests/__snapshots__/fragjto.test.ts.snap
+++ b/programs/restaking/tests/__snapshots__/fragjto.test.ts.snap
@@ -33,6 +33,10 @@ exports[`restaking.fragJTO test > restaking.fragJTO initializationTasks snapshot
   [
     "Program ComputeBudget111111111111111111111111111111 invoke [1]",
     "Program ComputeBudget111111111111111111111111111111 success",
+    "Program 11111111111111111111111111111111 invoke [1]",
+    "Program 11111111111111111111111111111111 success",
+    "Program 11111111111111111111111111111111 invoke [1]",
+    "Program 11111111111111111111111111111111 success",
     "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
     "Program log: CreateIdempotent",
     "Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb invoke [2]",

--- a/programs/restaking/tests/__snapshots__/fragsol.test.ts.snap
+++ b/programs/restaking/tests/__snapshots__/fragsol.test.ts.snap
@@ -33,6 +33,10 @@ exports[`restaking.fragSOL test > restaking.fragSOL initializationTasks snapshot
   [
     "Program ComputeBudget111111111111111111111111111111 invoke [1]",
     "Program ComputeBudget111111111111111111111111111111 success",
+    "Program 11111111111111111111111111111111 invoke [1]",
+    "Program 11111111111111111111111111111111 success",
+    "Program 11111111111111111111111111111111 invoke [1]",
+    "Program 11111111111111111111111111111111 success",
     "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
     "Program log: CreateIdempotent",
     "Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb invoke [2]",


### PR DESCRIPTION
- remove sol reserved migration logic
- pre-fund fund reserve/treasury accounts to prevent becoming non-rent-exempt accounts


https://github.com/fragmetric-labs/fragmetric-contracts/issues/350