### PR TITLE
fix(restaking/fund): change reward commission rate hard limit

### DIFF
--- a/programs/restaking/src/modules/fund/fund_account_restaking_vault.rs
+++ b/programs/restaking/src/modules/fund/fund_account_restaking_vault.rs
@@ -5,6 +5,7 @@ use crate::errors::ErrorCode;
 use crate::modules::pricing::{TokenPricingSource, TokenPricingSourcePod};
 
 pub const FUND_ACCOUNT_MAX_RESTAKING_VAULT_DELEGATIONS: usize = 30;
+pub const FUND_ACCOUNT_MAX_REWARD_COMMISSION_RATE_BPS: usize = 2_500;
 pub const FUND_ACCOUNT_MAX_RESTAKING_VAULT_COMPOUNDING_REWARD_TOKENS: usize = 4;
 pub const FUND_ACCOUNT_MAX_RESTAKING_VAULT_DISTRIBUTING_REWARD_TOKENS: usize = 30;
 
@@ -144,7 +145,10 @@ impl RestakingVault {
         reward_commission_rate_bps: u16,
     ) -> Result<&mut Self> {
         // hard limit on reward commission rate to be less than or equal to 25%
-        require_gte!(2_500, reward_commission_rate_bps);
+        require_gte!(
+            FUND_ACCOUNT_MAX_REWARD_COMMISSION_RATE_BPS,
+            reward_commission_rate_bps as usize
+        );
 
         self.reward_commission_rate_bps = reward_commission_rate_bps;
 

--- a/programs/restaking/tests/frag2.test.ts
+++ b/programs/restaking/tests/frag2.test.ts
@@ -1126,9 +1126,11 @@ describe('restaking.frag2 test', async () => {
         })
       );
 
+    const MAX_REWARD_COMMISSION_RATE_BPS = 2500;
+
     for (
       let rewardCommissionRateBps = 0;
-      rewardCommissionRateBps <= 2500;
+      rewardCommissionRateBps <= MAX_REWARD_COMMISSION_RATE_BPS;
       rewardCommissionRateBps += 130
     ) {
       await ctx.fund.runCommand.executeChained({
@@ -1263,14 +1265,14 @@ describe('restaking.frag2 test', async () => {
     await expect(
       ctx.fund.updateRestakingVaultStrategy.execute({
         vault: '6f4bndUq1ct6s7QxiHFk98b1Q7JdJw3zTTZBGbSPP6gK',
-        rewardCommissionRateBps: 2500,
+        rewardCommissionRateBps: MAX_REWARD_COMMISSION_RATE_BPS,
       })
     ).resolves.not.toThrow();
 
     await expect(
       ctx.fund.updateRestakingVaultStrategy.execute({
         vault: '6f4bndUq1ct6s7QxiHFk98b1Q7JdJw3zTTZBGbSPP6gK',
-        rewardCommissionRateBps: 2501,
+        rewardCommissionRateBps: MAX_REWARD_COMMISSION_RATE_BPS + 1,
       })
     ).rejects.toThrow();
 


### PR DESCRIPTION
change reward commission rate hard limit from `1000 bps(10%)` to `2500 bps(25%)`
related issue: #451 