### PR TITLE
test(solv): refine input relations

### DIFF
--- a/programs/solv/src/states/vault.rs
+++ b/programs/solv/src/states/vault.rs
@@ -1636,7 +1636,7 @@ mod tests {
     proptest! {
         #[test]
         fn test_initial_mint_vrt_with_vst(
-            vst_amount in 0..u64::MAX
+            vst_amount in 0..=BTC_MAX_SUPPLY
         ) {
             let mut vault = VaultAccount::dummy();
             let old_vault = vault.clone();
@@ -1661,9 +1661,9 @@ mod tests {
         #[test]
         fn test_mint_vrt_with_vst(
             mut vault in vault(),
-            mut vst_amount in 0..u64::MAX,
+            mut vst_amount in 0..=BTC_MAX_SUPPLY,
         ) {
-            vst_amount = vst_amount.min(u64::MAX - vault.vst_operation_reserved_amount);
+            vst_amount = vst_amount.min(BTC_MAX_SUPPLY - vault.vst_operation_reserved_amount);
             let old_vault = vault.clone();
 
             // VRT Price ≥ 1
@@ -1684,7 +1684,7 @@ mod tests {
         }
 
         #[test]
-        fn test_initial_mint_vrt_with_srt(srt_amount in 0..u64::MAX) {
+        fn test_initial_mint_vrt_with_srt(srt_amount in 0..=BTC_MAX_SUPPLY) {
             let mut vault = VaultAccount::dummy();
             let old_vault = vault.clone();
 


### PR DESCRIPTION
Refactored unit test in `solv/src/stats/vault.rs` as srt is now also depositable to solv

<img width="1086" height="508" alt="image" src="https://github.com/user-attachments/assets/b78f078d-5aa0-4a21-94a2-667004ede9d9" />

[https://whimsical.com/solv-vst-srt-relationship-FHTnzPzUNiR7DDhh2fQMaj](url)


- btc, vst, srt is correlated, so applied constraints below
  -  `vst` + `srt as vst` <= `BTC_MAX_SUPPLY`