### PR TITLE
fix(test): change test validator creation step

### DIFF
--- a/programs/restaking/tests/fragx.unit.test.ts
+++ b/programs/restaking/tests/fragx.unit.test.ts
@@ -26,7 +26,7 @@ describe('restaking.fragX unit test', async () => {
 
   beforeEach(async () => {
     testCtx = await initializeFragX(testSuiteCtx, index++);
-    testCtx.initializationTasks;
+    await testCtx.initializationTasks;
 
     ({ validator, feePayer, restaking, initializationTasks, ctx } = testCtx);
 


### PR DESCRIPTION
### Issue
In svm environment, fragX test suite fails because of hook timeout when running all of the test suites
```
 FAIL  programs/restaking/tests/fragx.unit.test.ts > restaking.fragX unit test
Error: Hook timed out in 300000ms.
If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
 ❯ programs/restaking/tests/fragx.unit.test.ts:33:3
     31|   let index = 0;
     32|
     33|   beforeAll(async () => (testSuiteCtx = await createTestSuiteContext()));
       |   ^
     34|   beforeEach(async () => {
     35|     testCtx = await initializeFragX(testSuiteCtx, index);
```

### Cause
There are 6 test suites. while fragX suite creates test validator in `beforeAll` block, other 5 suites create it right after describe block.
- fragX test suite
  ```typescript
  describe('restaking.fragX unit test', () => {
    let testCtx: Awaited<ReturnType<typeof initializeFragX>>;
    let validator: Awaited<ReturnType<typeof initializeFragX>>['validator'];
    let feePayer: Awaited<ReturnType<typeof initializeFragX>>['feePayer'];
    let restaking: Awaited<ReturnType<typeof initializeFragX>>['restaking'];
    let initializationTasks: Awaited<
      ReturnType<typeof initializeFragX>
    >['initializationTasks'];
    let ctx: RestakingReceiptTokenMintAccountContext;
    let testSuiteCtx: Awaited<ReturnType<typeof createTestSuiteContext>>;
  
    let signer1: KeyPairSigner, signer2: KeyPairSigner, signer3: KeyPairSigner;
    let user1: RestakingUserAccountContext,
      user2: RestakingUserAccountContext,
      user3: RestakingUserAccountContext;
  
    let index = 0;
    
    beforeAll(async () => (testSuiteCtx = await createTestSuiteContext()));     // test validator is created
  ```
- frag2 test suite
  ```typescript
  describe('restaking.frag2 test', async () => {
    const testCtx = await initializeFrag2(await createTestSuiteContext());    // test validator is created
  
    beforeAll(() => testCtx.initializationTasks);
    afterAll(() => testCtx.validator.quit());
  ```

In `vitest`, each test files are executed by different worker, so each test suites share resources to execute their code. In `describe` block code execution follows timeline below.
```
[collect]  import files
[collect]  describe(...) callback execution → "test/hook is registered”
---------------------------------------------
[execute]  beforeAll execution
[execute]  beforeEach → test #1 → afterEach
[execute]  beforeEach → test #2 → afterEach
[execute]  afterAll execution
```
while fragX test suite creates test validator during `collection phase`, all the other test suites' validators are created during `execution phase`. Creating a test validator needs a lot of time, especially if there are many test suites. fragX fail to create its validator in `beforeAll` hook block, so timeout error occurs.

### Solution
There are two options.
1) change hook timeout limit (greater than 300000ms)
2) make fragX test suite to create its validator in collection phase

Latter was applied in this PR to maintain consistency with other test suites


