### PR TITLE
refactor: replace std crate with core crate

### DIFF
--- a/programs/restaking/src/instructions/admin_fund_context.rs
+++ b/programs/restaking/src/instructions/admin_fund_context.rs
@@ -36,9 +36,9 @@ pub struct AdminFundAccountInitialContext<'info> {
         payer = payer,
         seeds = [FundAccount::SEED, receipt_token_mint.key().as_ref()],
         bump,
-        space = std::cmp::min(
+        space = core::cmp::min(
             solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE,
-            8 + std::mem::size_of::<FundAccount>(),
+            8 + core::mem::size_of::<FundAccount>(),
         ),
     )]
     pub fund_account: AccountLoader<'info, FundAccount>,

--- a/programs/restaking/src/instructions/admin_reward_context.rs
+++ b/programs/restaking/src/instructions/admin_reward_context.rs
@@ -25,9 +25,9 @@ pub struct AdminRewardAccountInitialContext<'info> {
         payer = payer,
         seeds = [RewardAccount::SEED, receipt_token_mint.key().as_ref()],
         bump,
-        space = std::cmp::min(
+        space = core::cmp::min(
             solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE,
-            8 + std::mem::size_of::<RewardAccount>(),
+            8 + core::mem::size_of::<RewardAccount>(),
         ),
     )]
     pub reward_account: AccountLoader<'info, RewardAccount>,

--- a/programs/restaking/src/modules/fund/commands/cmd10_harvest_restaking_yield.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd10_harvest_restaking_yield.rs
@@ -78,8 +78,8 @@ pub enum HarvestRestakingYieldState {
 
 use HarvestRestakingYieldState::*;
 
-impl std::fmt::Debug for HarvestRestakingYieldState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for HarvestRestakingYieldState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::New => write!(f, "New"),
             Self::NewCompoundReward => write!(f, "NewCompoundReward"),

--- a/programs/restaking/src/modules/fund/commands/cmd11_stake_sol.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd11_stake_sol.rs
@@ -17,8 +17,8 @@ pub struct StakeSOLCommandItem {
     allocated_sol_amount: u64,
 }
 
-impl std::fmt::Debug for StakeSOLCommandItem {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for StakeSOLCommandItem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}({})", self.token_mint, self.allocated_sol_amount)
     }
 }
@@ -41,8 +41,8 @@ pub enum StakeSOLCommandState {
     },
 }
 
-impl std::fmt::Debug for StakeSOLCommandState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for StakeSOLCommandState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::New => f.write_str("New"),
             Self::Prepare { items } => {

--- a/programs/restaking/src/modules/fund/commands/cmd12_normalize_st.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd12_normalize_st.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use core::ops::Neg;
 
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
@@ -20,8 +20,8 @@ pub struct NormalizeSTCommandItem {
     allocated_token_amount: u64,
 }
 
-impl std::fmt::Debug for NormalizeSTCommandItem {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NormalizeSTCommandItem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{}({})",
@@ -48,8 +48,8 @@ pub enum NormalizeSTCommandState {
     },
 }
 
-impl std::fmt::Debug for NormalizeSTCommandState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NormalizeSTCommandState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::New => f.write_str("New"),
             Self::Prepare { items } => {

--- a/programs/restaking/src/modules/fund/commands/cmd1_initialize.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd1_initialize.rs
@@ -52,8 +52,8 @@ pub enum InitializeCommandState {
 
 use InitializeCommandState::*;
 
-impl std::fmt::Debug for InitializeCommandState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for InitializeCommandState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::New => write!(f, "New"),
             Self::NewRestakingVaultUpdate => write!(f, "NewRestakingVaultUpdate"),

--- a/programs/restaking/src/modules/fund/commands/cmd4_denormalize_nt.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd4_denormalize_nt.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use core::ops::Neg;
 
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount};

--- a/programs/restaking/src/modules/fund/commands/cmd5_claim_unstaked_sol.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd5_claim_unstaked_sol.rs
@@ -37,8 +37,8 @@ pub enum ClaimUnstakedSOLCommandState {
 }
 use ClaimUnstakedSOLCommandState::*;
 
-impl std::fmt::Debug for ClaimUnstakedSOLCommandState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ClaimUnstakedSOLCommandState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             New => f.write_str("New"),
             Prepare { pool_token_mints } => {

--- a/programs/restaking/src/modules/fund/commands/cmd7_unstake_lst.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd7_unstake_lst.rs
@@ -19,8 +19,8 @@ pub struct UnstakeLSTCommandItem {
     allocated_token_amount: u64,
 }
 
-impl std::fmt::Debug for UnstakeLSTCommandItem {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for UnstakeLSTCommandItem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}({})", self.token_mint, self.allocated_token_amount)
     }
 }
@@ -53,8 +53,8 @@ pub enum UnstakeLSTCommandState {
     },
 }
 
-impl std::fmt::Debug for UnstakeLSTCommandState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for UnstakeLSTCommandState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::New => f.write_str("New"),
             Self::Prepare { items } => {

--- a/programs/restaking/src/modules/fund/commands/cmd8_unrestake_vrt.rs
+++ b/programs/restaking/src/modules/fund/commands/cmd8_unrestake_vrt.rs
@@ -1,5 +1,5 @@
-use std::iter::Peekable;
-use std::ops::Neg;
+use core::iter::Peekable;
+use core::ops::Neg;
 
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token;

--- a/programs/restaking/src/modules/fund/commands/mod.rs
+++ b/programs/restaking/src/modules/fund/commands/mod.rs
@@ -65,8 +65,8 @@ pub enum OperationCommand {
     DelegateVST(DelegateVSTCommand),
 }
 
-impl std::fmt::Debug for OperationCommand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for OperationCommand {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             OperationCommand::Initialize(command) => command.fmt(f),
             OperationCommand::EnqueueWithdrawalBatch(command) => command.fmt(f),
@@ -395,8 +395,8 @@ impl From<(Pubkey, bool)> for OperationCommandAccountMeta {
     }
 }
 
-impl std::fmt::Debug for OperationCommandAccountMeta {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for OperationCommandAccountMeta {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.pubkey.fmt(f)?;
         if self.is_writable {
             f.write_str("(W)")?;
@@ -563,11 +563,11 @@ pub(super) trait SelfExecutable: Into<OperationCommand> {
 }
 
 trait DebugStructExt {
-    fn field_first_element<T: std::fmt::Debug>(&mut self, name: &str, values: &[T]) -> &mut Self;
+    fn field_first_element<T: core::fmt::Debug>(&mut self, name: &str, values: &[T]) -> &mut Self;
 }
 
-impl DebugStructExt for std::fmt::DebugStruct<'_, '_> {
-    fn field_first_element<T: std::fmt::Debug>(&mut self, name: &str, values: &[T]) -> &mut Self {
+impl DebugStructExt for core::fmt::DebugStruct<'_, '_> {
+    fn field_first_element<T: core::fmt::Debug>(&mut self, name: &str, values: &[T]) -> &mut Self {
         if values.is_empty() {
             self
         } else {

--- a/programs/restaking/src/modules/fund/fund_account.rs
+++ b/programs/restaking/src/modules/fund/fund_account.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use core::ops::Neg;
 
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::spl_associated_token_account;
@@ -116,7 +116,7 @@ impl PDASeeds<3> for FundAccount {
         [
             Self::SEED,
             self.receipt_token_mint.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }
@@ -214,7 +214,7 @@ impl FundAccount {
     pub(super) fn get_reserve_account_seeds(&self) -> [&[u8]; 3] {
         let mut seeds = <[_; 3]>::default();
         seeds[..2].copy_from_slice(&self.get_reserve_account_seed_phrase());
-        seeds[2] = std::slice::from_ref(&self.reserve_account_bump);
+        seeds[2] = core::slice::from_ref(&self.reserve_account_bump);
         seeds
     }
 
@@ -235,7 +235,7 @@ impl FundAccount {
     pub(super) fn get_treasury_account_seeds(&self) -> [&[u8]; 3] {
         let mut seeds = <[_; 3]>::default();
         seeds[..2].copy_from_slice(&self.get_treasury_account_seed_phrase());
-        seeds[2] = std::slice::from_ref(&self.treasury_account_bump);
+        seeds[2] = core::slice::from_ref(&self.treasury_account_bump);
         seeds
     }
 
@@ -256,7 +256,7 @@ impl FundAccount {
     pub(super) fn get_wrap_account_seeds(&self) -> [&[u8]; 3] {
         let mut seeds = <[_; 3]>::default();
         seeds[..2].copy_from_slice(&self.get_wrap_account_seed_phrase());
-        seeds[2] = std::slice::from_ref(&self.wrap_account_bump);
+        seeds[2] = core::slice::from_ref(&self.wrap_account_bump);
         seeds
     }
 
@@ -830,14 +830,14 @@ impl FundAccount {
     }
 
     pub(super) fn get_asset_states_iter(&self) -> impl Iterator<Item = &AssetState> {
-        std::iter::once(&self.sol).chain(self.get_supported_tokens_iter().map(|v| &v.token))
+        core::iter::once(&self.sol).chain(self.get_supported_tokens_iter().map(|v| &v.token))
     }
 
     pub(super) fn get_asset_states_iter_mut(&mut self) -> impl Iterator<Item = &mut AssetState> {
         let tokens = self.supported_tokens[..self.num_supported_tokens as usize]
             .iter_mut()
             .map(|v| &mut v.token);
-        std::iter::once(&mut self.sol).chain(tokens)
+        core::iter::once(&mut self.sol).chain(tokens)
     }
 
     /// returns [deposited_amount]
@@ -1040,13 +1040,13 @@ impl<'a> FundStakeAccountAddress<'a> {
         [
             self.fund_account.as_ref(),
             self.pool_account.as_ref(),
-            std::slice::from_ref(&self.index),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.index),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }
 
-impl std::ops::Deref for FundStakeAccountAddress<'_> {
+impl core::ops::Deref for FundStakeAccountAddress<'_> {
     type Target = Pubkey;
 
     fn deref(&self) -> &Self::Target {
@@ -1095,13 +1095,13 @@ impl<'a> FundUnstakingTicketAddress<'a> {
             Self::SEED,
             self.fund_account.as_ref(),
             self.pool_account.as_ref(),
-            std::slice::from_ref(&self.index),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.index),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }
 
-impl std::ops::Deref for FundUnstakingTicketAddress<'_> {
+impl core::ops::Deref for FundUnstakingTicketAddress<'_> {
     type Target = Pubkey;
 
     fn deref(&self) -> &Self::Target {
@@ -1150,13 +1150,13 @@ impl<'a> FundUnrestakingTicketAddress<'a> {
             Self::SEED,
             self.fund_account.as_ref(),
             self.vault_account.as_ref(),
-            std::slice::from_ref(&self.index),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.index),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }
 
-impl std::ops::Deref for FundUnrestakingTicketAddress<'_> {
+impl core::ops::Deref for FundUnrestakingTicketAddress<'_> {
     type Target = Pubkey;
 
     fn deref(&self) -> &Self::Target {
@@ -1178,45 +1178,45 @@ mod tests {
 
     #[test]
     fn size_fund_account() {
-        let size = 8 + std::mem::size_of::<FundAccount>();
+        let size = 8 + core::mem::size_of::<FundAccount>();
         println!(
             "\nfund account size={}, version={}",
             size, FUND_ACCOUNT_CURRENT_VERSION
         );
         println!(
             "supported_token size={}",
-            std::mem::size_of::<SupportedToken>()
+            core::mem::size_of::<SupportedToken>()
         );
         println!(
             "operation_state size={}",
-            std::mem::size_of::<OperationState>()
+            core::mem::size_of::<OperationState>()
         );
         assert!(
             size < solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE
                 * (FUND_ACCOUNT_CURRENT_VERSION as usize)
         );
 
-        assert_eq!(std::mem::size_of::<FundAccount>() % 8, 0);
-        assert_eq!(std::mem::align_of::<FundAccount>(), 8);
+        assert_eq!(core::mem::size_of::<FundAccount>() % 8, 0);
+        assert_eq!(core::mem::align_of::<FundAccount>(), 8);
 
-        assert_eq!(std::mem::size_of::<WithdrawalBatch>() % 8, 0);
-        assert_eq!(std::mem::align_of::<WithdrawalBatch>(), 8);
+        assert_eq!(core::mem::size_of::<WithdrawalBatch>() % 8, 0);
+        assert_eq!(core::mem::align_of::<WithdrawalBatch>(), 8);
 
-        assert_eq!(std::mem::size_of::<SupportedToken>() % 8, 0);
-        assert_eq!(std::mem::align_of::<SupportedToken>(), 8);
+        assert_eq!(core::mem::size_of::<SupportedToken>() % 8, 0);
+        assert_eq!(core::mem::align_of::<SupportedToken>(), 8);
 
-        assert_eq!(std::mem::size_of::<NormalizedToken>() % 8, 0);
-        assert_eq!(std::mem::align_of::<NormalizedToken>(), 8);
+        assert_eq!(core::mem::size_of::<NormalizedToken>() % 8, 0);
+        assert_eq!(core::mem::align_of::<NormalizedToken>(), 8);
 
-        assert_eq!(std::mem::size_of::<RestakingVault>() % 8, 0);
-        assert_eq!(std::mem::align_of::<RestakingVault>(), 8);
+        assert_eq!(core::mem::size_of::<RestakingVault>() % 8, 0);
+        assert_eq!(core::mem::align_of::<RestakingVault>(), 8);
 
-        assert_eq!(std::mem::size_of::<OperationState>() % 8, 0);
-        assert_eq!(std::mem::align_of::<OperationState>(), 8);
+        assert_eq!(core::mem::size_of::<OperationState>() % 8, 0);
+        assert_eq!(core::mem::align_of::<OperationState>(), 8);
     }
 
     fn create_initialized_fund_account() -> FundAccount {
-        let buffer = [0u8; 8 + std::mem::size_of::<FundAccount>()];
+        let buffer = [0u8; 8 + core::mem::size_of::<FundAccount>()];
         let mut fund = FundAccount::try_deserialize_unchecked(&mut &buffer[..]).unwrap();
         fund.migrate(0, Pubkey::new_unique(), 9, 0).unwrap();
         fund

--- a/programs/restaking/src/modules/fund/fund_account_asset_state.rs
+++ b/programs/restaking/src/modules/fund/fund_account_asset_state.rs
@@ -224,7 +224,7 @@ impl AssetState {
         }
 
         let next_batch_id = self.withdrawal_pending_batch.batch_id + 1;
-        let mut pending_batch = std::mem::take(&mut self.withdrawal_pending_batch);
+        let mut pending_batch = core::mem::take(&mut self.withdrawal_pending_batch);
         self.withdrawal_pending_batch.initialize(next_batch_id);
         pending_batch.enqueued_at = current_timestamp;
 
@@ -250,7 +250,7 @@ impl AssetState {
         self.withdrawal_last_batch_processed_at = current_timestamp;
         // take `count` batches from front
         let processing_batches = (0..count)
-            .map(|i| std::mem::take(&mut self.withdrawal_queued_batches[i]))
+            .map(|i| core::mem::take(&mut self.withdrawal_queued_batches[i]))
             .collect();
         // then shift to left
         self.withdrawal_queued_batches[..self.withdrawal_num_queued_batches as usize]

--- a/programs/restaking/src/modules/fund/fund_configuration_service.rs
+++ b/programs/restaking/src/modules/fund/fund_configuration_service.rs
@@ -75,7 +75,7 @@ impl<'a, 'info> FundConfigurationService<'a, 'info> {
         )?;
 
         // initialize header or entire buffer
-        if self.fund_account.as_ref().data_len() < 8 + std::mem::size_of::<FundAccount>() {
+        if self.fund_account.as_ref().data_len() < 8 + core::mem::size_of::<FundAccount>() {
             self.fund_account
                 .initialize_zero_copy_header(fund_account_bump)?;
         } else {
@@ -108,9 +108,9 @@ impl<'a, 'info> FundConfigurationService<'a, 'info> {
         system_program: &Program<'info, System>,
         desired_account_size: Option<u32>,
     ) -> Result<()> {
-        let min_account_size = 8 + std::mem::size_of::<FundAccount>();
+        let min_account_size = 8 + core::mem::size_of::<FundAccount>();
         let target_account_size = desired_account_size
-            .map(|size| std::cmp::max(size as usize, min_account_size))
+            .map(|size| core::cmp::max(size as usize, min_account_size))
             .unwrap_or(min_account_size);
 
         let new_account_size = system_program.expand_account_size_if_needed(

--- a/programs/restaking/src/modules/fund/fund_service.rs
+++ b/programs/restaking/src/modules/fund/fund_service.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use core::ops::Neg;
 
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::spl_associated_token_account;

--- a/programs/restaking/src/modules/fund/fund_withdrawal_batch_account.rs
+++ b/programs/restaking/src/modules/fund/fund_withdrawal_batch_account.rs
@@ -68,7 +68,7 @@ impl FundWithdrawalBatchAccount {
     ) -> Vec<Vec<u8>> {
         let seed_phrase = Self::get_seed_phrase(receipt_token_mint, supported_token_mint, batch_id);
         let bump = Pubkey::find_program_address(
-            &std::array::from_fn::<_, 4, _>(|i| seed_phrase[i].as_slice()),
+            &core::array::from_fn::<_, 4, _>(|i| seed_phrase[i].as_slice()),
             &crate::ID,
         )
         .1;
@@ -86,7 +86,7 @@ impl FundWithdrawalBatchAccount {
     ) -> (Pubkey, u8) {
         let seed_phrase = Self::get_seed_phrase(receipt_token_mint, supported_token_mint, batch_id);
         Pubkey::find_program_address(
-            &std::array::from_fn::<_, 4, _>(|i| seed_phrase[i].as_slice()),
+            &core::array::from_fn::<_, 4, _>(|i| seed_phrase[i].as_slice()),
             &crate::ID,
         )
     }

--- a/programs/restaking/src/modules/fund/user_fund_account.rs
+++ b/programs/restaking/src/modules/fund/user_fund_account.rs
@@ -38,7 +38,7 @@ impl PDASeeds<4> for UserFundAccount {
             Self::SEED,
             self.receipt_token_mint.as_ref(),
             self.user.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }

--- a/programs/restaking/src/modules/normalization/normalized_token_pool_account.rs
+++ b/programs/restaking/src/modules/normalization/normalized_token_pool_account.rs
@@ -44,7 +44,7 @@ impl PDASeeds<3> for NormalizedTokenPoolAccount {
         [
             Self::SEED,
             self.normalized_token_mint.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }

--- a/programs/restaking/src/modules/normalization/normalized_token_withdrawal_account.rs
+++ b/programs/restaking/src/modules/normalization/normalized_token_withdrawal_account.rs
@@ -40,7 +40,7 @@ impl PDASeeds<4> for NormalizedTokenWithdrawalAccount {
             Self::SEED,
             self.normalized_token_mint.as_ref(),
             self.withdrawal_authority.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }

--- a/programs/restaking/src/modules/pricing/pricing_service.rs
+++ b/programs/restaking/src/modules/pricing/pricing_service.rs
@@ -208,7 +208,7 @@ impl<'info> PricingService<'info> {
 
         // expand supported tokens recursively
         // due to ownership, first we take numerator and return it back after recursion
-        let assets = std::mem::take(&mut self.token_values[token_index].numerator);
+        let assets = core::mem::take(&mut self.token_values[token_index].numerator);
         for asset in &assets {
             if let Asset::Token(token_mint, Some(token_pricing_source), _) = asset {
                 self.resolve_token_pricing_source_rec(

--- a/programs/restaking/src/modules/pricing/token_pricing_source.rs
+++ b/programs/restaking/src/modules/pricing/token_pricing_source.rs
@@ -48,8 +48,8 @@ pub enum TokenPricingSource {
     },
 }
 
-impl std::fmt::Display for TokenPricingSource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for TokenPricingSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::SPLStakePool { address } => write!(f, "SPLStakePool({})", address),
             Self::MarinadeStakePool { address } => write!(f, "MarinadeStakePool({})", address),

--- a/programs/restaking/src/modules/restaking/jito_restaking_vault_service.rs
+++ b/programs/restaking/src/modules/restaking/jito_restaking_vault_service.rs
@@ -105,7 +105,7 @@ impl<'info> JitoRestakingVaultService<'info> {
     #[inline(always)]
     fn borrow_account_data<'a, 'b>(
         account: &'a AccountInfo<'b>,
-    ) -> Result<std::cell::Ref<'a, &'b mut [u8]>> {
+    ) -> Result<core::cell::Ref<'a, &'b mut [u8]>> {
         require_keys_eq!(*account.owner, JITO_VAULT_PROGRAM_ID);
         Ok(account
             .data
@@ -115,7 +115,7 @@ impl<'info> JitoRestakingVaultService<'info> {
 
     #[inline(always)]
     fn deserialize_account_data<'a, T: jito_bytemuck::AccountDeserialize>(
-        data: &'a std::cell::Ref<&mut [u8]>,
+        data: &'a core::cell::Ref<&mut [u8]>,
     ) -> Result<&'a T> {
         Ok(T::try_from_slice_unchecked(data)?)
     }
@@ -650,7 +650,7 @@ impl<'info> JitoRestakingVaultService<'info> {
         ))?;
 
         // pay withdrawal ticket rent
-        let required_space = 8 + std::mem::size_of::<VaultUpdateStateTracker>();
+        let required_space = 8 + core::mem::size_of::<VaultUpdateStateTracker>();
 
         let current_lamports = withdrawal_ticket_account.get_lamports();
         let required_lamports = Rent::get()?

--- a/programs/restaking/src/modules/restaking/virtual_vault_service.rs
+++ b/programs/restaking/src/modules/restaking/virtual_vault_service.rs
@@ -78,7 +78,7 @@ impl<'a> VirtualVaultAddress<'a> {
             Self::SEED,
             self.vault_receipt_token_mint.as_ref(),
             self.fund_account.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }

--- a/programs/restaking/src/modules/reward/mod.rs
+++ b/programs/restaking/src/modules/reward/mod.rs
@@ -29,10 +29,10 @@ pub mod check_account_init_space {
     use super::*;
     use crate::modules::reward::reward_pool::RewardPool;
 
-    pub const CHECK_REWARD_ACCOUNT_SIZE: usize = 8 + std::mem::size_of::<RewardAccount>(); // 342064 ~= 335KB
-    pub const CHECK_REWARD_POOL_SIZE: usize = 8 + std::mem::size_of::<RewardPool>(); // 83440 ~= 81.5KiB
-    pub const CHECK_USER_REWARD_ACCOUNT_SIZE: usize = 8 + std::mem::size_of::<UserRewardAccount>(); // 4240 ~= 4.15KiB
-    pub const CHECK_USER_REWARD_POOL_SIZE: usize = 8 + std::mem::size_of::<UserRewardPool>(); // 1040 ~= 1.02KiB
+    pub const CHECK_REWARD_ACCOUNT_SIZE: usize = 8 + core::mem::size_of::<RewardAccount>(); // 342064 ~= 335KB
+    pub const CHECK_REWARD_POOL_SIZE: usize = 8 + core::mem::size_of::<RewardPool>(); // 83440 ~= 81.5KiB
+    pub const CHECK_USER_REWARD_ACCOUNT_SIZE: usize = 8 + core::mem::size_of::<UserRewardAccount>(); // 4240 ~= 4.15KiB
+    pub const CHECK_USER_REWARD_POOL_SIZE: usize = 8 + core::mem::size_of::<UserRewardPool>(); // 1040 ~= 1.02KiB
 
     #[test]
     fn check_size() {

--- a/programs/restaking/src/modules/reward/reward.rs
+++ b/programs/restaking/src/modules/reward/reward.rs
@@ -62,7 +62,7 @@ impl Reward {
     }
 
     pub fn get_name(&self) -> Result<&str> {
-        Ok(std::str::from_utf8(&self.name)
+        Ok(core::str::from_utf8(&self.name)
             .map_err(|_| ErrorCode::UTF8DecodingException)?
             .trim_matches('\0'))
     }

--- a/programs/restaking/src/modules/reward/reward_account.rs
+++ b/programs/restaking/src/modules/reward/reward_account.rs
@@ -51,7 +51,7 @@ impl PDASeeds<3> for RewardAccount {
         [
             Self::SEED,
             self.receipt_token_mint.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }
@@ -142,7 +142,7 @@ impl RewardAccount {
     pub(super) fn get_reserve_account_seeds(&self) -> [&[u8]; 3] {
         let mut seeds = <[_; 3]>::default();
         seeds[..2].copy_from_slice(&self.get_reserve_account_seed_phrase());
-        seeds[2] = std::slice::from_ref(&self.reserve_account_bump);
+        seeds[2] = core::slice::from_ref(&self.reserve_account_bump);
         seeds
     }
 

--- a/programs/restaking/src/modules/reward/reward_configuration_service.rs
+++ b/programs/restaking/src/modules/reward/reward_configuration_service.rs
@@ -27,7 +27,7 @@ impl<'a, 'info> RewardConfigurationService<'a, 'info> {
     }
 
     pub fn process_initialize_reward_account(&mut self, reward_account_bump: u8) -> Result<()> {
-        if self.reward_account.as_ref().data_len() < 8 + std::mem::size_of::<RewardAccount>() {
+        if self.reward_account.as_ref().data_len() < 8 + core::mem::size_of::<RewardAccount>() {
             self.reward_account
                 .initialize_zero_copy_header(reward_account_bump)
         } else {
@@ -45,9 +45,9 @@ impl<'a, 'info> RewardConfigurationService<'a, 'info> {
         system_program: &Program<'info, System>,
         desired_account_size: Option<u32>,
     ) -> Result<()> {
-        let min_account_size = 8 + std::mem::size_of::<RewardAccount>();
+        let min_account_size = 8 + core::mem::size_of::<RewardAccount>();
         let target_account_size = desired_account_size
-            .map(|size| std::cmp::max(size as usize, min_account_size))
+            .map(|size| core::cmp::max(size as usize, min_account_size))
             .unwrap_or(min_account_size);
 
         let new_account_size = system_program.expand_account_size_if_needed(

--- a/programs/restaking/src/modules/reward/token_allocated_amount.rs
+++ b/programs/restaking/src/modules/reward/token_allocated_amount.rs
@@ -266,7 +266,7 @@ enum OneOrManyDeltas<T: IntoIterator<Item = TokenAllocatedAmountDelta>> {
 }
 
 enum OneOrManyDeltasIter<T: Iterator<Item = TokenAllocatedAmountDelta>> {
-    One(std::option::IntoIter<TokenAllocatedAmountDelta>),
+    One(core::option::IntoIter<TokenAllocatedAmountDelta>),
     Many(T),
 }
 
@@ -303,7 +303,7 @@ mod tests {
         let mut amount = TokenAllocatedAmount::zeroed();
         amount.total_amount = 400;
         amount.num_records = 10;
-        amount.records = std::array::from_fn(|i| {
+        amount.records = core::array::from_fn(|i| {
             let mut record = TokenAllocatedAmountRecord::zeroed();
             record.contribution_accrual_rate = 100 + i as u16 * 10;
             record.amount = non_empty.contains(&i).then_some(100).unwrap_or_default();

--- a/programs/restaking/src/modules/reward/user_reward_account.rs
+++ b/programs/restaking/src/modules/reward/user_reward_account.rs
@@ -46,7 +46,7 @@ impl PDASeeds<4> for UserRewardAccount {
             Self::SEED,
             self.receipt_token_mint.as_ref(),
             self.user.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 }

--- a/programs/restaking/src/modules/reward/user_reward_configuration_service.rs
+++ b/programs/restaking/src/modules/reward/user_reward_configuration_service.rs
@@ -37,7 +37,7 @@ impl<'a, 'info> UserRewardConfigurationService<'a, 'info> {
         delegate: Option<Pubkey>,
         desired_account_size: Option<u32>,
     ) -> Result<Option<events::UserCreatedOrUpdatedRewardAccount>> {
-        let min_account_size = 8 + std::mem::size_of::<UserRewardAccount>();
+        let min_account_size = 8 + core::mem::size_of::<UserRewardAccount>();
         let new_account_size = if self.user_reward_account.is_initialized() {
             let user_reward_account =
                 AccountLoader::<UserRewardAccount>::try_from(self.user_reward_account)?;
@@ -59,9 +59,9 @@ impl<'a, 'info> UserRewardConfigurationService<'a, 'info> {
                 None,
             )?
         } else {
-            let new_account_size = std::cmp::min(
+            let new_account_size = core::cmp::min(
                 solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE,
-                8 + std::mem::size_of::<UserRewardAccount>(),
+                8 + core::mem::size_of::<UserRewardAccount>(),
             );
 
             system_program.initialize_account(

--- a/programs/restaking/src/modules/staking/marinade_stake_pool_service.rs
+++ b/programs/restaking/src/modules/staking/marinade_stake_pool_service.rs
@@ -307,7 +307,7 @@ impl<'info> MarinadeStakePoolService<'info> {
             new_withdrawal_ticket_account,
             new_withdrawal_ticket_account_rent_payer, // payer is already signer so we don't need signer seeds
             new_withdrawal_ticket_account_seeds,
-            8 + std::mem::size_of::<TicketAccountData>(),
+            8 + core::mem::size_of::<TicketAccountData>(),
             None,
             &marinade_cpi::marinade::ID,
         )?;

--- a/programs/restaking/src/modules/staking/spl_stake_pool_service.rs
+++ b/programs/restaking/src/modules/staking/spl_stake_pool_service.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use core::num::NonZeroU32;
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
@@ -31,7 +31,7 @@ where
     pool_account: &'info AccountInfo<'info>, // deserialize on-demand
     pool_token_mint: &'info AccountInfo<'info>,
     pool_token_program: &'info AccountInfo<'info>,
-    _marker: std::marker::PhantomData<T>,
+    _marker: core::marker::PhantomData<T>,
 }
 
 impl<T: SPLStakePoolInterface> ValidateStakePool for SPLStakePoolService<'_, T> {

--- a/programs/restaking/src/modules/staking/spl_stake_pool_value_provider.rs
+++ b/programs/restaking/src/modules/staking/spl_stake_pool_value_provider.rs
@@ -5,7 +5,7 @@ use crate::modules::pricing::{Asset, TokenValue, TokenValueProvider};
 use super::{SPLStakePool, SPLStakePoolInterface, SPLStakePoolService};
 
 pub struct SPLStakePoolValueProvider<T: SPLStakePoolInterface = SPLStakePool> {
-    _marker: std::marker::PhantomData<T>,
+    _marker: core::marker::PhantomData<T>,
 }
 
 impl<T: SPLStakePoolInterface> Default for SPLStakePoolValueProvider<T> {

--- a/programs/restaking/src/utils.rs
+++ b/programs/restaking/src/utils.rs
@@ -227,7 +227,7 @@ where
     T: ZeroCopy + Owner + Clone,
 {
     fn as_account_info(&self) -> &'info AccountInfo<'info> {
-        unsafe { std::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
+        unsafe { core::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
     }
 }
 
@@ -236,7 +236,7 @@ where
     T: AccountSerialize + AccountDeserialize + Clone,
 {
     fn as_account_info(&self) -> &'info AccountInfo<'info> {
-        unsafe { std::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
+        unsafe { core::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
     }
 }
 
@@ -245,25 +245,25 @@ where
     T: AccountSerialize + AccountDeserialize + Clone,
 {
     fn as_account_info(&self) -> &'info AccountInfo<'info> {
-        unsafe { std::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
+        unsafe { core::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
     }
 }
 
 impl<'info, T> AsAccountInfo<'info> for Program<'info, T> {
     fn as_account_info(&self) -> &'info AccountInfo<'info> {
-        unsafe { std::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
+        unsafe { core::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
     }
 }
 
 impl<'info, T> AsAccountInfo<'info> for Interface<'info, T> {
     fn as_account_info(&self) -> &'info AccountInfo<'info> {
-        unsafe { std::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
+        unsafe { core::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
     }
 }
 
 impl<'info> AsAccountInfo<'info> for UncheckedAccount<'info> {
     fn as_account_info(&self) -> &'info AccountInfo<'info> {
-        unsafe { std::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
+        unsafe { core::mem::transmute::<&AccountInfo, _>(self.as_ref()) }
     }
 }
 
@@ -414,7 +414,7 @@ impl<'info> SystemProgramExt<'info> for Program<'info, System> {
                 msg!("realloc account lamports: added={}", required_lamports);
             }
 
-            let increase = std::cmp::min(
+            let increase = core::cmp::min(
                 required_realloc_size,
                 entrypoint::MAX_PERMITTED_DATA_INCREASE,
             );

--- a/programs/solv/src/states/vault.rs
+++ b/programs/solv/src/states/vault.rs
@@ -172,7 +172,7 @@ impl VaultAccount {
     pub const SEED: &'static [u8] = b"vault";
 
     pub const fn get_size() -> usize {
-        8 + std::mem::size_of::<Self>()
+        8 + core::mem::size_of::<Self>()
     }
 
     pub fn is_initialized(&self) -> bool {
@@ -191,7 +191,7 @@ impl VaultAccount {
         [
             Self::SEED,
             self.vault_receipt_token_mint.as_ref(),
-            std::slice::from_ref(&self.bump),
+            core::slice::from_ref(&self.bump),
         ]
     }
 
@@ -741,7 +741,7 @@ impl VaultAccount {
             .saturating_sub(self.get_appropriate_vst_deducted_fee_amount()?);
 
         let offsetting_vst_deducted_fee_amount =
-            std::cmp::min(vst_amount, vst_over_deducted_fee_amount);
+            core::cmp::min(vst_amount, vst_over_deducted_fee_amount);
 
         vst_amount -= offsetting_vst_deducted_fee_amount;
         self.vst_deducted_fee_amount -= offsetting_vst_deducted_fee_amount;
@@ -749,7 +749,7 @@ impl VaultAccount {
 
         // Offset VST receivables
         let offsetting_vst_operation_receivable_amount =
-            std::cmp::min(vst_amount, self.vst_operation_receivable_amount);
+            core::cmp::min(vst_amount, self.vst_operation_receivable_amount);
 
         self.vst_operation_reserved_amount += offsetting_vst_operation_receivable_amount;
         self.vst_operation_receivable_amount -= offsetting_vst_operation_receivable_amount;
@@ -777,7 +777,7 @@ impl VaultAccount {
         let maximum_possible_srt_donation_amount = srt_exchange_rate
             .get_vst_amount_as_srt(self.vst_operation_receivable_amount, false)
             .ok_or_else(|| error!(VaultError::CalculationArithmeticException))?;
-        srt_amount = std::cmp::min(srt_amount, maximum_possible_srt_donation_amount);
+        srt_amount = core::cmp::min(srt_amount, maximum_possible_srt_donation_amount);
 
         let srt_operation_reserved_amount_as_vst = srt_exchange_rate
             .get_srt_amount_as_vst(self.srt_operation_reserved_amount, false)
@@ -945,7 +945,7 @@ impl VaultAccount {
             )
             .ok_or_else(|| error!(VaultError::CalculationArithmeticException))?
         };
-        vrt_amount = std::cmp::min(vrt_amount, maximum_possible_vst_withdrawal_amount);
+        vrt_amount = core::cmp::min(vrt_amount, maximum_possible_vst_withdrawal_amount);
 
         // Ignore empty request
         if vrt_amount == 0 {
@@ -982,7 +982,7 @@ impl VaultAccount {
         };
 
         // Then, pay with VST reserved as much as possible, in order to avoid solv protocol withdrawal fee
-        let vst_withdrawal_locked_amount = std::cmp::min(
+        let vst_withdrawal_locked_amount = core::cmp::min(
             self.vst_operation_reserved_amount,
             target_vst_withdrawal_amount - target_vst_offsetting_receivable_amount,
         );
@@ -1044,7 +1044,7 @@ impl VaultAccount {
             let net_asset_value_decreased_amount_by_srt_withdrawal =
                 srt_operation_reserved_amount_as_vst - post_srt_operation_reserved_amount_as_vst;
             let diff = insufficient_vst_amount - net_asset_value_decreased_amount_by_srt_withdrawal;
-            vst_offsetting_receivable_amount = std::cmp::min(
+            vst_offsetting_receivable_amount = core::cmp::min(
                 self.vst_operation_receivable_amount,
                 target_vst_offsetting_receivable_amount + diff,
             );
@@ -1321,7 +1321,7 @@ impl VaultAccount {
             let vst_over_deducted_fee_amount =
                 self.vst_deducted_fee_amount - appropriate_vst_deducted_fee_amount;
             let amount_to_offset =
-                std::cmp::min(vst_over_deducted_fee_amount, self.vst_extra_amount_to_claim);
+                core::cmp::min(vst_over_deducted_fee_amount, self.vst_extra_amount_to_claim);
 
             // Offset over deducted fee
             self.vst_extra_amount_to_claim -= amount_to_offset;


### PR DESCRIPTION
(This PR proposes a small refactor to improve the repository’s quality)

Solana programs are compiled to BPF bytecode and run inside the Solana runtime environment, which does not provide an operating system or the Rust standard library (std). Because of this, any std usage is inappropriate in on-chain contexts — it may compile locally but will not be available in the BPF target environment.

- Solana programs run in a `no_std` BPF VM environment.
- `std` depends on an operating system and is not available on-chain.
- `core` is the correct foundational crate for `no_std` targets.
- improves portability and correctness of the on-chain code.

P.S.
Although some std APIs may appear to work locally, they often just re-export functionality from core.
Using the std path in on-chain code can be misleading and risky, as it may accidentally pull in std dependencies and cause build failures on BPF.
Referencing core directly makes the no_std nature of the code explicit and future-proof.