### PR TITLE
refactor: remove redundant macros

### DIFF
--- a/programs/restaking/src/modules/fund/commands/mod.rs
+++ b/programs/restaking/src/modules/fund/commands/mod.rs
@@ -346,7 +346,6 @@ const FUND_ACCOUNT_OPERATION_COMMAND_BUFFER_SIZE: usize = 3126;
 
 /// Pod type of `Option<OperationCommand>`
 #[zero_copy]
-#[repr(C)]
 pub struct OperationCommandPod {
     discriminant: u8,
     buffer: [u8; FUND_ACCOUNT_OPERATION_COMMAND_BUFFER_SIZE],
@@ -412,9 +411,8 @@ impl OperationCommandAccountMeta {
     }
 }
 
-#[zero_copy]
-#[repr(C)]
 /// Pod type of `OperationCommandAccountMeta`
+#[zero_copy]
 pub struct OperationCommandAccountMetaPod {
     pubkey: Pubkey,
     is_writable: u8,
@@ -468,7 +466,6 @@ impl OperationCommandEntry {
 
 /// Pod type of `Option<OperationCommandEntry>`
 #[zero_copy]
-#[repr(C)]
 pub struct OperationCommandEntryPod {
     num_required_accounts: u8,
     _padding: [u8; 7],

--- a/programs/restaking/src/modules/fund/fund_account_asset_state.rs
+++ b/programs/restaking/src/modules/fund/fund_account_asset_state.rs
@@ -9,7 +9,6 @@ use super::WithdrawalRequest;
 pub const FUND_ACCOUNT_MAX_QUEUED_WITHDRAWAL_BATCHES: usize = 10;
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct AssetState {
     token_mint: Pubkey,
     token_program: Pubkey,
@@ -363,7 +362,6 @@ impl AssetState {
 }
 
 #[zero_copy]
-#[repr(C)]
 #[derive(Default)]
 pub(super) struct WithdrawalBatch {
     pub batch_id: u64,

--- a/programs/restaking/src/modules/fund/fund_account_normalized_token.rs
+++ b/programs/restaking/src/modules/fund/fund_account_normalized_token.rs
@@ -4,7 +4,6 @@ use bytemuck::Zeroable;
 use crate::modules::pricing::{TokenPricingSource, TokenPricingSourcePod};
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct NormalizedToken {
     pub mint: Pubkey,
     pub program: Pubkey,

--- a/programs/restaking/src/modules/fund/fund_account_operation_state.rs
+++ b/programs/restaking/src/modules/fund/fund_account_operation_state.rs
@@ -5,7 +5,6 @@ use super::commands::*;
 const FUND_ACCOUNT_OPERATION_COMMAND_EXPIRATION_SECONDS: i64 = 600;
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct OperationState {
     updated_slot: u64,
     updated_at: i64,

--- a/programs/restaking/src/modules/fund/fund_account_restaking_vault.rs
+++ b/programs/restaking/src/modules/fund/fund_account_restaking_vault.rs
@@ -65,7 +65,6 @@ pub(super) struct RestakingVault {
 }
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct TokenExchangeRatio {
     pub numerator: u64,
     pub denominator: u64,
@@ -429,7 +428,6 @@ impl RestakingVault {
 }
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct RestakingVaultDelegation {
     pub operator: Pubkey,
 
@@ -466,7 +464,6 @@ impl RestakingVaultDelegation {
 }
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct RewardToken {
     pub mint: Pubkey,
     pub harvest_threshold_min_amount: u64,

--- a/programs/restaking/src/modules/fund/fund_account_supported_token.rs
+++ b/programs/restaking/src/modules/fund/fund_account_supported_token.rs
@@ -7,7 +7,6 @@ use crate::modules::pricing::{TokenPricingSource, TokenPricingSourcePod};
 use super::AssetState;
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct SupportedToken {
     pub mint: Pubkey,
     pub program: Pubkey,

--- a/programs/restaking/src/modules/fund/fund_account_token_swap_strategy.rs
+++ b/programs/restaking/src/modules/fund/fund_account_token_swap_strategy.rs
@@ -19,7 +19,6 @@ use crate::modules::swap::{TokenSwapSource, TokenSwapSourcePod};
 /// In this case `to_token` need not be one of fund's supported token.
 /// However, to prevent endless swap, token swap strategies must form DAG(vertex = token, edge = strategy).
 #[zero_copy]
-#[repr(C)]
 pub(super) struct TokenSwapStrategy {
     pub from_token_mint: Pubkey,
     pub to_token_mint: Pubkey,

--- a/programs/restaking/src/modules/fund/fund_account_wrapped_token.rs
+++ b/programs/restaking/src/modules/fund/fund_account_wrapped_token.rs
@@ -7,7 +7,6 @@ use crate::errors::ErrorCode;
 pub const FUND_ACCOUNT_MAX_WRAPPED_TOKEN_HOLDERS: usize = 30;
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct WrappedToken {
     pub mint: Pubkey,
     pub program: Pubkey,
@@ -164,7 +163,6 @@ impl WrappedToken {
 }
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct WrappedTokenHolder {
     pub token_account: Pubkey,
     pub amount: u64,

--- a/programs/restaking/src/modules/pricing/token_pricing_source.rs
+++ b/programs/restaking/src/modules/pricing/token_pricing_source.rs
@@ -142,7 +142,6 @@ impl TokenPricingSource {
 
 /// Pod type of `Option<TokenPricingSource>`
 #[zero_copy]
-#[repr(C)]
 pub struct TokenPricingSourcePod {
     discriminant: u8,
     _padding: [u8; 7],

--- a/programs/restaking/src/modules/pricing/token_value_provider.rs
+++ b/programs/restaking/src/modules/pricing/token_value_provider.rs
@@ -99,7 +99,6 @@ impl TokenValue {
 
 /// Pod type of `TokenValue`
 #[zero_copy]
-#[repr(C)]
 pub struct TokenValuePod {
     pub numerator: [AssetPod; TOKEN_VALUE_MAX_NUMERATORS_SIZE],
     pub num_numerator: u64,
@@ -237,7 +236,6 @@ impl Asset {
 
 /// Pod type of `Asset`
 #[zero_copy]
-#[repr(C)]
 pub struct AssetPod {
     pub discriminant: u8,
     _padding: [u8; 7],

--- a/programs/restaking/src/modules/reward/reward.rs
+++ b/programs/restaking/src/modules/reward/reward.rs
@@ -8,7 +8,6 @@ const REWARD_DESCRIPTION_MAX_LEN: usize = 128;
 
 /// Reward type.
 #[zero_copy]
-#[repr(C)]
 pub(super) struct Reward {
     /// ID is determined by reward account.
     pub id: u16,

--- a/programs/restaking/src/modules/reward/token_allocated_amount.rs
+++ b/programs/restaking/src/modules/reward/token_allocated_amount.rs
@@ -8,7 +8,6 @@ const MIN_CONTRIBUTION_ACCRUAL_RATE: u16 = 100;
 const MAX_CONTRIBUTION_ACCRUAL_RATE: u16 = 500;
 
 #[zero_copy]
-#[repr(C)]
 pub(super) struct TokenAllocatedAmount {
     total_amount: u64,
     num_records: u8,
@@ -172,7 +171,6 @@ impl TokenAllocatedAmount {
 }
 
 #[zero_copy]
-#[repr(C)]
 struct TokenAllocatedAmountRecord {
     amount: u64,
     /// Contribution accrual rate per 1 lamports (decimals = 2)

--- a/programs/restaking/src/modules/swap/token_swap_source.rs
+++ b/programs/restaking/src/modules/swap/token_swap_source.rs
@@ -19,7 +19,6 @@ impl TokenSwapSource {
 
 /// Pod type of `TokenSwapSource`
 #[zero_copy]
-#[repr(C)]
 pub struct TokenSwapSourcePod {
     discriminant: u8,
     _padding: [u8; 7],

--- a/programs/solv/src/states/vault.rs
+++ b/programs/solv/src/states/vault.rs
@@ -133,7 +133,6 @@ pub struct VaultAccount {
 
 const BPS: u16 = 10_000;
 
-#[repr(C)]
 #[zero_copy]
 #[derive(Default)]
 #[cfg_attr(test, derive(Debug, PartialEq))]


### PR DESCRIPTION
`#[zero_copy]` attribute macro is a convenient alias for

(1) `#[derive(Copy, Clone)]`
(2) `#[derive(bytemuck::Zeroable)]`,
(3) `#[derive(bytemuck::Pod)]`, 
(4) `#[repr(C)]`

it's unnecessary to declare `repr(C)` again